### PR TITLE
#966: column renamed from Date to Sale Date

### DIFF
--- a/src/dashboard/deals/index.tsx
+++ b/src/dashboard/deals/index.tsx
@@ -40,7 +40,7 @@ const renderColumnsData: TableColumnsList[] = [
     { field: "accountInfo", header: "Account" },
     { field: "contactinfo", header: "Customer" },
     { field: "dealtype", header: "Type" },
-    { field: "created", header: "Date" },
+    { field: "created", header: "Sale Date" },
     { field: "inventoryinfo", header: "Info (Vehicle)" },
 ];
 


### PR DESCRIPTION
Уточню, на всякий случай: у нас в колонке Sale Date отображено поле created (дата создания записи) - это правильное поле, оно и отвечает за дату сделки?