### PR TITLE
#971: enhance promise confirmation dialog and tooltip functionality

### DIFF
--- a/src/dashboard/accounts/form/promise-to-pay/index.css
+++ b/src/dashboard/accounts/form/promise-to-pay/index.css
@@ -124,3 +124,26 @@
         }
     }
 }
+
+.promise-confirm-dialog {
+    .p-dialog-content {
+        padding-top: 28px;
+    }
+    .confirm-header__icon {
+        font-size: 5.5rem;
+        padding-bottom: 35px;
+    }
+
+    .p-dialog-footer {
+        padding-top: 42px;
+        padding-bottom: 50px;
+        .p-button {
+            display: inline-flex;
+            justify-content: center;
+            align-items: center;
+            padding: 0;
+            width: 130px;
+            height: 60px;
+        }
+    }
+}


### PR DESCRIPTION
Проблема была в том, что prime меню генерировалось после инициализации Tooltip. Пришлось навешивать слушатель событий и постоянно отслеживать изменения, иначе тултипы отображаться не будут. Так же изменил размеры, иконку и привел в соотвествие с дизайном модалку подтвержения удаления. 