### PR TITLE
#973: enhance AutoCompleteDropdown functionality clear button

### DIFF
--- a/src/dashboard/common/form/autocomplete/index.tsx
+++ b/src/dashboard/common/form/autocomplete/index.tsx
@@ -14,6 +14,7 @@ export const AutoCompleteDropdown = ({
     onClear,
     clearButton = false,
     dropdown = true,
+    value,
     ...props
 }: AutoCompleteDropdownProps): ReactElement => {
     const [isDropdownVisible, setIsDropdownVisible] = useState(false);
@@ -28,11 +29,27 @@ export const AutoCompleteDropdown = ({
         }
     }, []);
 
+    useEffect(() => {
+        if (!value && autoCompleteRef.current) {
+            autoCompleteRef.current.hide();
+            setIsDropdownVisible(false);
+        }
+    }, [value]);
+
+    const handleClear = () => {
+        if (autoCompleteRef.current) {
+            autoCompleteRef.current.hide();
+            setIsDropdownVisible(false);
+        }
+        onClear?.();
+    };
+
     return (
         <div className='p-inputgroup autocomplete-dropdown' ref={containerRef}>
             <span className='p-float-label'>
                 <AutoComplete
                     {...props}
+                    value={value}
                     dropdown={dropdown}
                     inputClassName='autocomplete-dropdown__input'
                     ref={autoCompleteRef}
@@ -76,12 +93,12 @@ export const AutoCompleteDropdown = ({
                 />
                 <label className='float-label'>{label}</label>
             </span>
-            {clearButton && !!props.value && (
+            {clearButton && !!value && (
                 <Button
                     icon='pi pi-times'
                     type='button'
                     className='autocomplete-dropdown__clear-button'
-                    onClick={onClear}
+                    onClick={handleClear}
                 />
             )}
         </div>

--- a/src/dashboard/contacts/form/contact-info/prospecting/index.tsx
+++ b/src/dashboard/contacts/form/contact-info/prospecting/index.tsx
@@ -123,6 +123,7 @@ export const ContactsProspecting = observer((): ReactElement => {
                     onClear={() => {
                         setProspectInput(null);
                         changeContactExtData("PROSPECT1_ID", "");
+                        setProspectList(initialProspectList);
                     }}
                 />
             </div>
@@ -152,6 +153,7 @@ export const ContactsProspecting = observer((): ReactElement => {
                         onClear={() => {
                             setProspectSecondInput(null);
                             changeContactExtData("PROSPECT2_ID", "");
+                            setProspectList(initialProspectList);
                         }}
                         clearButton
                     />


### PR DESCRIPTION
Сейчас при очистке через крестик просто вызывается стандартное поведение https://primereact.org/autocomplete/. Т.е. данные в инпуте очистились - дроп закрылся и подгрузил изначальный список. Я пробовал несколько способов сделать так, что-бы дроп не закрывался, а сразу отображал все значения - но компонент, к сожалению, это не дает реализовать (пробовал и через ref принудительно вызывать обновление списка и через прямое обращение к компоненту через классы и т.п.) - компонент просто перестает корректную отработку в дальнейшем. Можно, конечно, влезть и переписать сам компонент, но в случае обновления либы это все сломается, потому такой способ очень не желателен.  