### PR TITLE
#1046-test: add test end-point with status code 500 & enhance error handling in API services

### DIFF
--- a/src/dashboard/sidebar/index.tsx
+++ b/src/dashboard/sidebar/index.tsx
@@ -7,12 +7,16 @@ import { Button } from "primereact/button";
 import { Tooltip } from "primereact/tooltip";
 import { getUserSettings, setUserSettings } from "http/services/auth-user.service";
 import { ServerUserSettings } from "common/models/user";
+import { testTask } from "http/services/tasks.service";
+import { useToast } from "dashboard/common/toast";
+import { TOAST_LIFETIME } from "common/settings";
 
 export const Sidebar = observer((): ReactElement => {
     const store = useStore().userStore;
     const { authUser, settings, isSettingsLoaded } = store;
     const [isSalesPerson, setIsSalesPerson] = useState(true);
     const [serverSettings, setServerSettings] = useState<ServerUserSettings | undefined>(undefined);
+    const toast = useToast();
 
     useEffect(() => {
         if (authUser) {
@@ -64,17 +68,50 @@ export const Sidebar = observer((): ReactElement => {
         }
     }, [authUser, authUser?.permissions]);
 
-    const renderNavItem = (to: string, iconClass: string, label: string): ReactElement => {
-        const itemId = `nav-item-${to.replace(/\//g, "-")}`;
+    const handleTestTask = async () => {
+        if (!authUser) return;
+
+        const result = await testTask(authUser.useruid);
+        if (result?.status === "OK") {
+            toast?.current?.show({
+                severity: "success",
+                summary: "Test Task",
+                detail: "Test task completed successfully!",
+                life: TOAST_LIFETIME,
+            });
+        } else {
+            toast.current?.show({
+                severity: "error",
+                summary: "Test Task Error",
+                detail: result?.error,
+                life: 3000,
+            });
+        }
+    };
+
+    const renderNavItem = (
+        to: string | null,
+        iconClass: string,
+        label: string,
+        onClick?: () => void
+    ): ReactElement => {
+        const itemId = `nav-item-${to?.replace(/\//g, "-")}`;
         return (
             <li className='sidebar-nav__item'>
                 {settings.isSidebarCollapsed && (
                     <Tooltip target={`#${itemId}`} content={label} position='right' />
                 )}
-                <Link to={to} id={itemId} className='sidebar-nav__link'>
-                    <div className={`sidebar-nav__icon ${iconClass}`}></div>
-                    {!settings.isSidebarCollapsed && <span>{label}</span>}
-                </Link>
+                {to ? (
+                    <Link to={to} id={itemId} className='sidebar-nav__link'>
+                        <div className={`sidebar-nav__icon ${iconClass}`}></div>
+                        {!settings.isSidebarCollapsed && <span>{label}</span>}
+                    </Link>
+                ) : (
+                    <div id={itemId} className='sidebar-nav__link' onClick={onClick}>
+                        <div className={`sidebar-nav__icon ${iconClass}`}></div>
+                        {!settings.isSidebarCollapsed && <span>{label}</span>}
+                    </div>
+                )}
             </li>
         );
     };
@@ -113,6 +150,8 @@ export const Sidebar = observer((): ReactElement => {
                         {renderNavItem("/dashboard/tasks", "tasks", "Tasks")}
                     </>
                 )}
+                {authUser?.loginname === "testError" &&
+                    renderNavItem(null, "tasks", "Test Error", handleTestTask)}
             </ul>
         </aside>
     );

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,7 +1,8 @@
-import axios, { AxiosInstance } from "axios";
+import axios, { AxiosError, AxiosInstance } from "axios";
 import { getKeyValue } from "services/local-storage.service";
 import { AuthUser } from "./services/auth.service";
 import { LS_APP_USER } from "common/constants/localStorage";
+import { NavigateFunction } from "react-router-dom";
 
 export const APP_TYPE: string = process.env.REACT_APP_TYPE || "client";
 export const APP_VERSION: string = process.env.REACT_APP_VERSION || "0.1";
@@ -22,17 +23,20 @@ export const nonAuthorizedUserApiInstance = axios.create({
     baseURL: APP_API_URL,
 });
 
-const handleErrorResponse = (error: any, navigate: any) => {
+const handleErrorResponse = (error: AxiosError, navigate: NavigateFunction) => {
     if (error.response && error.response.status === 401) {
         localStorage.removeItem("useruid");
         navigate("/");
+        return Promise.reject(error.response);
+    } else if (error.response && error.response.status === 500) {
+        navigate("/service-update");
         return Promise.reject(error.response);
     } else {
         return Promise.reject(error);
     }
 };
 
-export function createApiDashboardInstance(navigate: any) {
+export function createApiDashboardInstance(navigate: NavigateFunction) {
     authorizedUserApiInstance = axios.create({
         baseURL: APP_API_URL,
         headers: {

--- a/src/http/routes/ErrorBoundary.tsx
+++ b/src/http/routes/ErrorBoundary.tsx
@@ -4,7 +4,6 @@ import { NotFound } from "not-found";
 import { useToast } from "dashboard/common/toast";
 import { AxiosError } from "axios";
 import { TOAST_LIFETIME } from "common/settings";
-import { ServiceUpdate } from "services/service-update";
 
 export const ErrorBoundary = (): ReactElement | null => {
     const error = useRouteError() as AxiosError;
@@ -12,8 +11,6 @@ export const ErrorBoundary = (): ReactElement | null => {
 
     if (error?.status === 404 || error?.response?.status === 404) {
         return <NotFound />;
-    } else if (error?.status === 500 || error?.response?.status === 500) {
-        return <ServiceUpdate />;
     }
 
     toast.current?.show({

--- a/src/http/services/tasks.service.ts
+++ b/src/http/services/tasks.service.ts
@@ -126,3 +126,19 @@ export const setTaskStatus = async (taskuid: string, taskStatus: TaskStatus) => 
         }
     }
 };
+
+export const testTask = async (useruid: string) => {
+    try {
+        const request = await authorizedUserApiInstance.post<BaseResponseError>(
+            `tasks/${useruid}/test`
+        );
+        return request.data;
+    } catch (error) {
+        if (isAxiosError(error)) {
+            return {
+                status: Status.ERROR,
+                error: error.response?.data.error || "Error while testing task",
+            };
+        }
+    }
+};


### PR DESCRIPTION
Для пользователя testError добавлен элемент на боковой панели:
![image](https://github.com/user-attachments/assets/0ad3c505-bb3e-4b88-aa13-6e655e95e856)

---

Так же изменен уровень обработки ошибки (перенесен на уровень interceptor).

---

От этой ветки будет новое ответвление [(task-1046)](https://github.com/kamabzalov/admss-client/pull/1076) где будет вырезано все лишнее, а именно: АПИ для тестирования и лишний код для его проверки, но где сохраняться правки, которые отвечают именно за обработку status code.