### PR TITLE
#1177: implement custom dialog hook and enhance toast styling

### DIFF
--- a/src/dashboard/accounts/form/insuranse/index.tsx
+++ b/src/dashboard/accounts/form/insuranse/index.tsx
@@ -1,22 +1,36 @@
 import { TabView, TabPanel } from "primereact/tabview";
-import { ReactElement } from "react";
+import { ReactElement, forwardRef, useImperativeHandle, useRef } from "react";
 import { AccountInsuranceHistory } from "./insurance-history";
-import { AccountInsuranceInfo } from "./insurance-info";
+import { AccountInsuranceInfo, InsuranceInfoRef } from "./insurance-info";
 import "./index.css";
 
-export const AccountInsurance = (): ReactElement => (
-    <div className='account-insurance'>
-        <div className='grid'>
-            <div className='col-12'>
-                <TabView className='account-insurance__tabs'>
-                    <TabPanel header='Insurance'>
-                        <AccountInsuranceInfo />
-                    </TabPanel>
-                    <TabPanel header='Insurance history'>
-                        <AccountInsuranceHistory />
-                    </TabPanel>
-                </TabView>
+export interface AccountInsuranceRef {
+    hasUnsavedChanges: () => boolean;
+}
+
+export const AccountInsurance = forwardRef<AccountInsuranceRef>((_, ref): ReactElement => {
+    const insuranceInfoRef = useRef<InsuranceInfoRef>(null);
+
+    useImperativeHandle(ref, () => ({
+        hasUnsavedChanges: () => {
+            return insuranceInfoRef.current?.hasUnsavedChanges() || false;
+        },
+    }));
+
+    return (
+        <div className='account-insurance'>
+            <div className='grid'>
+                <div className='col-12'>
+                    <TabView className='account-insurance__tabs'>
+                        <TabPanel header='Insurance'>
+                            <AccountInsuranceInfo ref={insuranceInfoRef} />
+                        </TabPanel>
+                        <TabPanel header='Insurance history'>
+                            <AccountInsuranceHistory />
+                        </TabPanel>
+                    </TabView>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+});

--- a/src/dashboard/accounts/form/insuranse/insurance-info/index.tsx
+++ b/src/dashboard/accounts/form/insuranse/insurance-info/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useEffect, useState, useImperativeHandle, forwardRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { getAccountInsurance, updateAccountInsurance } from "http/services/accounts.service";
 import { Checkbox } from "primereact/checkbox";
@@ -12,50 +12,37 @@ import { Status } from "common/models/base-response";
 import { useToast } from "dashboard/common/toast";
 import { TOAST_LIFETIME } from "common/settings";
 import { Loader } from "dashboard/common/loader";
+import { CONTACTS_PAGE } from "common/constants/links";
 
-export const AccountInsuranceInfo = observer((): ReactElement => {
-    const { id } = useParams();
-    const navigate = useNavigate();
-    const toast = useToast();
-    const [insuranceInfo, setInsuranceInfo] = useState<AccountInsurance>();
-    const store = useStore().accountStore;
-    const [insuranceEdit, setInsuranceEdit] = useState<boolean>(true);
-    const [isLoading, setIsLoading] = useState<boolean>(false);
-    const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
+export interface InsuranceInfoRef {
+    hasUnsavedChanges: () => boolean;
+}
 
-    const {
-        accountExtData: { Title_Received, Title_Num },
-        changeAccountExtData,
-    } = store;
+export const AccountInsuranceInfo = observer(
+    forwardRef<InsuranceInfoRef>((_, ref): ReactElement => {
+        const { id } = useParams();
+        const navigate = useNavigate();
+        const toast = useToast();
+        const [insuranceInfo, setInsuranceInfo] = useState<AccountInsurance>();
+        const store = useStore().accountStore;
+        const [insuranceEdit, setInsuranceEdit] = useState<boolean>(true);
+        const [isLoading, setIsLoading] = useState<boolean>(false);
+        const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
+        const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
 
-    const handleGetInsuranceHistory = async () => {
-        if (id) {
-            setIsLoading(true);
-            getAccountInsurance(id).then((res) => {
-                if (res?.status === Status.ERROR) {
-                    toast.current?.show({
-                        severity: "error",
-                        summary: Status.ERROR,
-                        detail: res.error,
-                        life: TOAST_LIFETIME,
-                    });
-                }
-                if (res) {
-                    setInsuranceInfo(res as AccountInsurance);
-                    setIsLoading(false);
-                }
-            });
-        }
-    };
+        const {
+            accountExtData: { Title_Received, Title_Num },
+            changeAccountExtData,
+        } = store;
 
-    useEffect(() => {
-        handleGetInsuranceHistory();
-    }, [id]);
+        useImperativeHandle(ref, () => ({
+            hasUnsavedChanges: () => hasUnsavedChanges,
+        }));
 
-    const handleChangeInsuranceInfo = () => {
-        if (insuranceInfo) {
-            id &&
-                updateAccountInsurance(id, insuranceInfo).then((res) => {
+        const handleGetInsuranceHistory = async () => {
+            if (id) {
+                setIsLoading(true);
+                getAccountInsurance(id).then((res) => {
                     if (res?.status === Status.ERROR) {
                         toast.current?.show({
                             severity: "error",
@@ -63,155 +50,187 @@ export const AccountInsuranceInfo = observer((): ReactElement => {
                             detail: res.error,
                             life: TOAST_LIFETIME,
                         });
-                    } else {
+                    }
+                    if (res) {
                         setInsuranceInfo(res as AccountInsurance);
-                        handleGetInsuranceHistory().then(() => {
-                            setInsuranceEdit(true);
-                            setIsButtonDisabled(true);
-                        });
-                        toast.current?.show({
-                            severity: "success",
-                            summary: "Success",
-                            detail: "Insurance info updated successfully!",
-                            life: TOAST_LIFETIME,
-                        });
+                        setIsLoading(false);
                     }
                 });
-        }
-    };
+            }
+        };
 
-    const handleChangeInsuranceEdit = () => {
-        if (!insuranceInfo?.Insurance_userUID) {
-            toast.current?.show({
-                severity: "error",
-                summary: "Error",
-                detail: "Insurance userUID is required",
-                life: TOAST_LIFETIME,
-            });
-        } else {
-            navigate(`/dashboard/contacts/${insuranceInfo?.Insurance_userUID}`);
-        }
-    };
+        useEffect(() => {
+            handleGetInsuranceHistory();
+        }, [id]);
 
-    const handleChangeInsurance = (field: keyof AccountInsurance, value: string) => {
-        setIsButtonDisabled(false);
-        setInsuranceInfo((prev) => ({ ...prev!, [field]: value }));
-    };
+        const handleChangeInsuranceInfo = () => {
+            if (insuranceInfo) {
+                id &&
+                    updateAccountInsurance(id, insuranceInfo).then((res) => {
+                        if (res?.status === Status.ERROR) {
+                            toast.current?.show({
+                                severity: "error",
+                                summary: Status.ERROR,
+                                detail: res.error,
+                                life: TOAST_LIFETIME,
+                            });
+                        } else {
+                            setInsuranceInfo(res as AccountInsurance);
+                            handleGetInsuranceHistory().then(() => {
+                                setInsuranceEdit(true);
+                                setIsButtonDisabled(true);
+                                setHasUnsavedChanges(false);
+                            });
+                            toast.current?.show({
+                                severity: "success",
+                                summary: "Success",
+                                detail: "Insurance info updated successfully!",
+                                life: TOAST_LIFETIME,
+                            });
+                        }
+                    });
+            }
+        };
 
-    return (
-        <div className='insurance-info'>
-            <div className='insurance-info__container'>
-                {isLoading ? (
-                    <Loader />
-                ) : (
-                    <>
-                        <div className='insurance-info__item insurance-info--splitter'>
-                            <InsuranceInfoField
-                                label='Insurance Company'
-                                value={insuranceInfo?.Insurance_Company}
-                                onChange={(e) => handleChangeInsurance("Insurance_Company", e)}
-                                editMode={insuranceEdit}
-                            />
-                            <InsuranceInfoField
-                                label='Insurance Agent'
-                                value={insuranceInfo?.Insurance_Agent_Name}
-                                onChange={(e) => handleChangeInsurance("Insurance_Agent_Name", e)}
-                                editMode={insuranceEdit}
-                            />
-                            <InsuranceInfoField
-                                label='Policy#'
-                                value={insuranceInfo?.Insurance_Policy_Number}
-                                onChange={(e) =>
-                                    handleChangeInsurance("Insurance_Policy_Number", e)
-                                }
-                                editMode={insuranceEdit}
-                            />
+        const handleChangeInsuranceEdit = () => {
+            if (!insuranceInfo?.Insurance_userUID) {
+                toast.current?.show({
+                    severity: "error",
+                    summary: "Error",
+                    detail: "Insurance userUID is required",
+                    life: TOAST_LIFETIME,
+                });
+            } else {
+                navigate(CONTACTS_PAGE.EDIT(insuranceInfo?.Insurance_userUID));
+            }
+        };
 
-                            <div className='insurance-field'>
-                                <Checkbox
-                                    inputId='account-insurance-policy'
-                                    name='account-insurance-policy'
-                                    checked={!!insuranceInfo?.Insurance_Policy_Received}
-                                    onClick={() => {
-                                        setIsButtonDisabled(false);
-                                        setInsuranceInfo((prev) => ({
-                                            ...prev!,
-                                            Insurance_Policy_Received:
-                                                !prev?.Insurance_Policy_Received ? 1 : 0,
-                                        }));
-                                    }}
+        const handleChangeInsurance = (field: keyof AccountInsurance, value: string) => {
+            setIsButtonDisabled(false);
+            setHasUnsavedChanges(true);
+            setInsuranceInfo((prev) => ({ ...prev!, [field]: value }));
+        };
+
+        return (
+            <div className='insurance-info'>
+                <div className='insurance-info__container'>
+                    {isLoading ? (
+                        <Loader />
+                    ) : (
+                        <>
+                            <div className='insurance-info__item insurance-info--splitter'>
+                                <InsuranceInfoField
+                                    label='Insurance Company'
+                                    value={insuranceInfo?.Insurance_Company}
+                                    onChange={(e) => handleChangeInsurance("Insurance_Company", e)}
+                                    editMode={insuranceEdit}
                                 />
-                                <label
-                                    htmlFor='account-insurance-policy'
-                                    className='ml-2 insurance-field__label insurance-field__label--thin'
-                                >
-                                    Insurance Policy Received
-                                </label>
+                                <InsuranceInfoField
+                                    label='Insurance Agent'
+                                    value={insuranceInfo?.Insurance_Agent_Name}
+                                    onChange={(e) =>
+                                        handleChangeInsurance("Insurance_Agent_Name", e)
+                                    }
+                                    editMode={insuranceEdit}
+                                />
+                                <InsuranceInfoField
+                                    label='Policy#'
+                                    value={insuranceInfo?.Insurance_Policy_Number}
+                                    onChange={(e) =>
+                                        handleChangeInsurance("Insurance_Policy_Number", e)
+                                    }
+                                    editMode={insuranceEdit}
+                                />
+
+                                <div className='insurance-field'>
+                                    <Checkbox
+                                        inputId='account-insurance-policy'
+                                        name='account-insurance-policy'
+                                        checked={!!insuranceInfo?.Insurance_Policy_Received}
+                                        onClick={() => {
+                                            setIsButtonDisabled(false);
+                                            setHasUnsavedChanges(true);
+                                            setInsuranceInfo((prev) => ({
+                                                ...prev!,
+                                                Insurance_Policy_Received:
+                                                    !prev?.Insurance_Policy_Received ? 1 : 0,
+                                            }));
+                                        }}
+                                    />
+                                    <label
+                                        htmlFor='account-insurance-policy'
+                                        className='ml-2 insurance-field__label insurance-field__label--thin'
+                                    >
+                                        Insurance Policy Received
+                                    </label>
+                                </div>
+                                <InsuranceInfoField
+                                    label='Expiration Date'
+                                    value={insuranceInfo?.Insurance_Exp_Date}
+                                    editMode={insuranceEdit}
+                                    inputType='date'
+                                />
                             </div>
-                            <InsuranceInfoField
-                                label='Expiration Date'
-                                value={insuranceInfo?.Insurance_Exp_Date}
-                                editMode={insuranceEdit}
-                                inputType='date'
-                            />
-                        </div>
-                        <div className='insurance-info__item'>
-                            <div className='insurance-field'>
-                                <Checkbox
-                                    inputId='account-insurance-title-received'
-                                    name='account-insurance-title-received'
-                                    checked={!!Title_Received}
-                                    onClick={() => {
-                                        setIsButtonDisabled(false);
-                                        changeAccountExtData(
-                                            "Title_Received",
-                                            !Title_Received ? 1 : 0
-                                        );
-                                    }}
-                                />
-                                <label
-                                    htmlFor='account-insurance-title-received'
-                                    className='insurance-field__label ml-2 insurance-field__label--thin'
-                                >
-                                    Title Received
-                                </label>
+                            <div className='insurance-info__item'>
+                                <div className='insurance-field'>
+                                    <Checkbox
+                                        inputId='account-insurance-title-received'
+                                        name='account-insurance-title-received'
+                                        checked={!!Title_Received}
+                                        onClick={() => {
+                                            setIsButtonDisabled(false);
+                                            setHasUnsavedChanges(true);
+                                            changeAccountExtData(
+                                                "Title_Received",
+                                                !Title_Received ? 1 : 0
+                                            );
+                                        }}
+                                    />
+                                    <label
+                                        htmlFor='account-insurance-title-received'
+                                        className='insurance-field__label ml-2 insurance-field__label--thin'
+                                    >
+                                        Title Received
+                                    </label>
+                                </div>
+                                <span className='p-float-label'>
+                                    <InputText
+                                        id='account-insurance-title-num'
+                                        className='insurance-info__input w-full'
+                                        value={Title_Num}
+                                        onChange={(e) => {
+                                            setIsButtonDisabled(false);
+                                            setHasUnsavedChanges(true);
+                                            changeAccountExtData("Title_Num", e.target.value);
+                                        }}
+                                    />
+                                    <label className='float-label'>Title#</label>
+                                </span>
                             </div>
-                            <span className='p-float-label'>
-                                <InputText
-                                    id='account-insurance-title-num'
-                                    className='insurance-info__input w-full'
-                                    value={Title_Num}
-                                    onChange={(e) => {
-                                        setIsButtonDisabled(false);
-                                        changeAccountExtData("Title_Num", e.target.value);
-                                    }}
-                                />
-                                <label className='float-label'>Title#</label>
-                            </span>
-                        </div>
-                    </>
-                )}
+                        </>
+                    )}
+                    <div className='insurance-info__footer'>
+                        <Button
+                            type='button'
+                            className='insurance-info__button'
+                            disabled={isButtonDisabled}
+                            severity={isButtonDisabled ? "secondary" : "success"}
+                            onClick={handleChangeInsuranceInfo}
+                        >
+                            Save
+                        </Button>
+                    </div>
+                </div>
                 <div className='insurance-info__footer'>
                     <Button
-                        type='button'
-                        className='insurance-info__button'
-                        disabled={isButtonDisabled}
-                        severity={isButtonDisabled ? "secondary" : "success"}
-                        onClick={handleChangeInsuranceInfo}
+                        className='insurance-info__button insurance-info__button--edit'
+                        onClick={handleChangeInsuranceEdit}
+                        outlined
                     >
-                        Save
+                        View/ Edit Contact Information
                     </Button>
                 </div>
             </div>
-            <div className='insurance-info__footer'>
-                <Button
-                    className='insurance-info__button insurance-info__button--edit'
-                    onClick={handleChangeInsuranceEdit}
-                    outlined
-                >
-                    View/ Edit Contact Information
-                </Button>
-            </div>
-        </div>
-    );
-});
+        );
+    })
+);

--- a/src/dashboard/common/toast/index.css
+++ b/src/dashboard/common/toast/index.css
@@ -1,3 +1,59 @@
-.p-toast-summary {
-    text-transform: uppercase;
+.p-toast {
+    --toast-warn-color: var(--admss-app-warning-yellow);
+    --toast-info-color: var(--admss-app-warning-blue);
+    --toast-error-color: var(--admss-app-red);
+    --toast-success-color: var(--admss-app-warning-green);
+    .p-toast-summary {
+        text-transform: uppercase;
+    }
+
+    height: 40px;
+
+    margin: 0;
+
+    .p-toast-message {
+        font-weight: 400;
+        font-size: 18px;
+        font-family: "Open Sans", sans-serif;
+        .p-toast-message-content .p-toast-message-icon.p-icon {
+            width: 4rem;
+            height: 4rem;
+        }
+
+        &.p-toast-message-warn {
+            border-left: 10px solid var(--toast-warn-color);
+            color: var(--toast-warn-color);
+            .p-toast-message-icon.p-icon,
+            .p-toast-icon-close {
+                color: var(--toast-warn-color);
+            }
+        }
+
+        &.p-toast-message-info {
+            border-left: 10px solid var(--toast-info-color);
+            color: var(--toast-info-color);
+            .p-toast-message-icon.p-icon,
+            .p-toast-icon-close {
+                color: var(--toast-info-color);
+            }
+        }
+
+        &.p-toast-message-error {
+            border-left: 10px solid var(--toast-error-color);
+            color: var(--toast-error-color);
+            .p-toast-message-icon.p-icon,
+            .p-toast-icon-close {
+                color: var(--toast-error-color);
+            }
+        }
+
+        &.p-toast-message-success {
+            border-left: 10px solid var(--toast-success-color);
+            color: var(--toast-success-color);
+            .p-toast-message-icon.p-icon,
+            .p-toast-icon-close {
+                color: var(--toast-success-color);
+            }
+        }
+    }
 }

--- a/src/dashboard/index.css
+++ b/src/dashboard/index.css
@@ -778,3 +778,31 @@ figure {
     margin-inline-start: 0;
     margin-inline-end: 0;
 }
+
+.quit-editing {
+    font-family: "Open Sans", sans-serif;
+    height: 451px;
+    .confirm-header__icon {
+        font-size: 6rem;
+        padding-bottom: 24px;
+    }
+
+    .confirm-header__title {
+        padding-top: 0;
+    }
+
+    .confirm-body {
+        letter-spacing: 0px;
+    }
+
+    .p-dialog-footer .p-button {
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        padding: 0;
+        height: 60px;
+        width: 130px;
+        font-size: 20px;
+        font-weight: 700;
+    }
+}

--- a/src/dashboard/reports/form/index.tsx
+++ b/src/dashboard/reports/form/index.tsx
@@ -25,7 +25,8 @@ import { TreeNode } from "primereact/treenode";
 import { Status } from "common/models/base-response";
 import { buildTreeNodes } from "../common/drag-and-drop";
 import { TreeNodeEvent } from "common/models";
-import { ConfirmModal } from "dashboard/common/dialog/confirm";
+import { useFormExitConfirmation } from "common/hooks";
+import { REPORTS_PAGE } from "common/constants/links";
 
 const COLLECTION_DRAG_DELAY = 1000;
 const DEEPLY_NESTED_LEVEL = 3;
@@ -109,9 +110,14 @@ export const ReportForm = observer((): ReactElement => {
     const [favoriteCollections, setFavoriteCollections] = useState<ReportCollection[]>([]);
     const [expandedKeys, setExpandedKeys] = useState<{ [key: string]: boolean }>({});
     const expandedForId = useRef<string | null>(null);
-    const [confirmActive, setConfirmActive] = useState<boolean>(false);
     const hoverTimerRef = useRef<NodeJS.Timeout | null>(null);
     const [currentNodeOrder, setCurrentNodeOrder] = useState<number | null>(null);
+
+    const { handleExitClick, ConfirmModalComponent } = useFormExitConfirmation({
+        isFormChanged: isReportChanged,
+        onConfirmExit: () => navigate(REPORTS_PAGE.MAIN),
+        className: "report-confirm-dialog",
+    });
 
     const getCollections = useCallback(async () => {
         if (authUser) {
@@ -420,24 +426,12 @@ export const ReportForm = observer((): ReactElement => {
         getUserReportCollections(true);
     };
 
-    const navigateToReports = () => {
-        navigate("/dashboard/reports");
-    };
-
-    const handleCloseClick = () => {
-        if (isReportChanged) {
-            setConfirmActive(true);
-        } else {
-            navigateToReports();
-        }
-    };
-
     return (
         <div className='grid relative'>
             <Button
                 icon='pi pi-times'
                 className='p-button close-button'
-                onClick={handleCloseClick}
+                onClick={handleExitClick}
             />
             <div className='col-12'>
                 <div className='card report'>
@@ -490,19 +484,7 @@ export const ReportForm = observer((): ReactElement => {
                     <ReportFooter onRefetch={() => getUserReportCollections(true)} />
                 </div>
             </div>
-            <ConfirmModal
-                visible={confirmActive}
-                draggable={false}
-                position='top'
-                className='contact-delete-dialog'
-                title='Quit Editing?'
-                icon='pi-exclamation-triangle'
-                bodyMessage='Are you sure you want to leave this page? All unsaved data will be lost.'
-                rejectLabel='Cancel'
-                acceptLabel='Confirm'
-                confirmAction={navigateToReports}
-                onHide={() => setConfirmActive(false)}
-            />
+            <ConfirmModalComponent />
         </div>
     );
 });


### PR DESCRIPTION
Создал сразу кастомный единый хук для всех компонентов. Потому что у нас сейчас в приложении в каждой из форм данная модалка (подтверджения покидая формы без сохранения) отличалась по размерам (дизайну). Теперь же стили приведены в соответствии с дизайном. Аналогично сделал с toast - теперь они такие же, как и в дизайне.