### PR TITLE
#1425: update key prop in LatestLeads component to prioritize dealuid over itemuid

### DIFF
--- a/src/dashboard/leads/widget/index.tsx
+++ b/src/dashboard/leads/widget/index.tsx
@@ -77,7 +77,7 @@ export const LatestLeads = ({
 
                             return (
                                 <div
-                                    key={lead.itemuid}
+                                    key={lead.dealuid || lead.itemuid}
                                     className='latest-leads__row'
                                     onClick={() =>
                                         navigate(LEADS_PAGE.EDIT(lead.dealuid), {


### PR DESCRIPTION

<img width="1340" height="386" alt="image" src="https://github.com/user-attachments/assets/0fb38a86-f2c3-433c-8cce-cb9c4b8e490f" />
фикс консольной ошибки из-за одинаковых ключей при рендере списка